### PR TITLE
Битая ссылка

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ URL: http://yaoziyuan.googlepages.com/SizeBalancedTree.zip
 Аналогичную задачу выполняют binary search trees, определенные
 японскими исследователями Youchi Hirai и Kazuhiko Yamamoto.
 Статья "Balancing weight-balanced trees",
-URL: http://hagi.is.s.u-tokyo.ac.jp/~yh/bst.pdf
+URL: https://yoichihirai.com/bst.pdf
 (Cambridge University Press, 2011 год)
 
 Работа японских исследователей выглядит внушительно, и их


### PR DESCRIPTION
Сайт переехал с http://hagi.is.s.u-tokyo.ac.jp/~yh в https://yoichihirai.com
